### PR TITLE
fix: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,21 @@
 
 Do you want to add the config to your own projects? There you go:
 
-1. Add this package to your devDependencies (`npm i -D @nuxtjs/eslint-config` or `yarn add -D @nuxtjs/eslint-config`)
+1. Add this package to your devDependencies
+```bash
+$ npm i -D @nuxtjs/eslint-config
+// or
+$ yarn add -D @nuxtjs/eslint-config
+```
 2. Add the [`peerDependencies`](./package.json) to your project
 
-`npm i -D eslint eslint-config-standard eslint-plugin-import eslint-plugin-jest eslint-plugin-node eslint-plugin-promise eslint-plugin-standard eslint-plugin-vue`
+```bash
+$ npm i -D eslint eslint-config-standard eslint-plugin-import eslint-plugin-jest eslint-plugin-node eslint-plugin-promise eslint-plugin-standard eslint-plugin-vue
+// or
+$ yarn add -D eslint eslint-config-standard eslint-plugin-import eslint-plugin-jest eslint-plugin-node eslint-plugin-promise eslint-plugin-standard eslint-plugin-vue
+```
 
-3. Create a `.eslintrc.js` file
+3. Create a `.eslintrc` file
 
 4. Extend our config (you can use just the scope name as ESLint will assume the `eslint-config` prefix):
 
@@ -27,6 +36,23 @@ Do you want to add the config to your own projects? There you go:
 }
 ```
 
+## Full example
+
+A full example `.eslintrc` for a project with babel support:
+> Dont forget to `npm i -D babel-eslint` or `yarn add -D babel-eslint`
+
+```json
+{
+  "root": true,
+  "parserOptions": {
+    "parser": "babel-eslint",
+    "sourceType": "module"
+  },
+  "extends": [
+    "@nuxtjs"
+  ]
+}
+```
 
 ## License
 


### PR DESCRIPTION
Updated the readme a bit
- step 3 used an incorrect extension
- a full example with babel support would help probably too. Thats mainly because when I switched to this package I didnt realize myself that that part of Nuxt's eslint config was not included here ;)