### PR TITLE
chore: change curly rule to prevent lonely ifs

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,9 @@ module.exports = {
     // No single if in an "else" block
     'no-lonely-if': 2,
 
-    // Force curly braces for control flow
-    curly: 2,
+    // Force curly braces for control flow,
+    // including if blocks with a single statement
+    curly: [2, 'all'],
 
     // No async function without await
     'require-await': 2,


### PR DESCRIPTION
This change will force code like:

```js
if (typeof p === 'string') p = { src: p }
```

To be always written in a proper block:

```js
if (typeof p === 'string') {
  p = { src: p }
}
```

I think lonely ifs are a bad pattern in keeping the code as maintainable as possible. 

This change will require a subsequent PR to nuxt.js itself to fix offending occurrences.

Already have a branch with it, just waiting for this to be approved first -- that is, if I can get you guys to agree with me :)