### PR TITLE
feat: prefer destructuring

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ module.exports = {
     // Force dot notation when possible
     'dot-notation': 2,
 
+    // Prefer destructuring over normal assignment
+    'prefer-destructuring': [2, { 'object': true, 'array': false }],
+    
     'no-var': 2,
 
     // Do not allow console.logs etc...

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = {
         "array": true,
         "object": false
       }
-    }]
+    }],
 
     'no-var': 2,
 

--- a/index.js
+++ b/index.js
@@ -63,13 +63,13 @@ module.exports = {
 
     // Prefer destructuring over normal assignment
     'prefer-destructuring': [2, {
-      "VariableDeclarator": {
-        "array": true,
-        "object": true
+      'VariableDeclarator': {
+        'array': true,
+        'object': true
       },
-      "AssignmentExpression": {
-        "array": true,
-        "object": false
+      'AssignmentExpression': {
+        'array': true,
+        'object': false
       }
     }],
 

--- a/index.js
+++ b/index.js
@@ -71,8 +71,6 @@ module.exports = {
         "array": true,
         "object": false
       }
-    }, {
-      "enforceForRenamedProperties": false
     }]
 
     'no-var': 2,

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = {
 
     // Prefer destructuring over normal assignment
     'prefer-destructuring': [2, { 'object': true, 'array': false }],
-    
+
     'no-var': 2,
 
     // Do not allow console.logs etc...

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = {
         "object": false
       }
     }, {
-      "enforceForRenamedProperties": true
+      "enforceForRenamedProperties": false
     }]
 
     'no-var': 2,

--- a/index.js
+++ b/index.js
@@ -62,7 +62,18 @@ module.exports = {
     'dot-notation': 2,
 
     // Prefer destructuring over normal assignment
-    'prefer-destructuring': [2, { 'object': true, 'array': false }],
+    'prefer-destructuring': [2, {
+      "VariableDeclarator": {
+        "array": true,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": true,
+        "object": false
+      }
+    }, {
+      "enforceForRenamedProperties": true
+    }]
 
     'no-var': 2,
 

--- a/tests/validate-config.test.js
+++ b/tests/validate-config.test.js
@@ -1,7 +1,7 @@
 const eslint = require('eslint')
 
 test('load config in eslint to validate all rule syntax is correct', () => {
-  const CLIEngine = eslint.CLIEngine
+  const { CLIEngine } = eslint
 
   const cli = new CLIEngine({
     useEslintrc: false,


### PR DESCRIPTION
Use https://eslint.org/docs/rules/prefer-destructuring to prefer destructuring instead of direct assignment in multiple lines.

**Update**: Enforce this rule except for re-assignment for objects.

Example what **will not be enforced**:

```js
let a
let b
let c

({a, b, c} = fooObject)
``` 

## Positions

**Unsure**

* @pi0 
* @Atinux 

**No**

* @galvez 

**Yes**

* @manniL 