### PR TITLE
Please avoid changing basic StandardJS rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,10 +64,6 @@ module.exports = {
     'no-var': 2,
 
     // Do not allow console.logs etc...
-    'space-before-function-paren': [2, {
-      anonymous: 'always',
-      named: 'never'
-    }],
     'vue/no-parsing-error': [2, {
       'x-invalid-end-tag': false
     }],

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -5,6 +5,6 @@ test('test basic properties of config', () => {
   expect(isObject(config.rules)).toBe(true)
 })
 
-function isObject(obj) {
+function isObject (obj) {
   return typeof obj === 'object' && obj !== null
 }


### PR DESCRIPTION
Hi, I'm a huge fan of Nuxt.js and recently I generated new Nuxt.js project with `create-nuxt-app`.

I found `create-nuxt-app` sets up ESLint with `@nuxtjs/eslint-config` and I think this is a great idea because everyone who starts to develop Nuxt.js application needs less laborious setting up processes.

That's why I strongly insist that changing basic StandardJS rules must be avoided.

Please customize your rules only with your terminatory project, not with commonly used library.