### PR TITLE
feat: warn console and debugger in dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ module.exports = {
     'generator-star-spacing': 'off',
 
     // Allow debugger during development
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
 
     // Prefer const over let
     'prefer-const': ['error', {


### PR DESCRIPTION
Instead of turning off no-console in development and displaying error in production, it would be better to show some warning message for development usage.

Why not turning it off or use `error` in development:

- App won't be broken if user adds `console.log` in dev mode with `eslint-loader`
- User can still get warning messages for inappropriate usage instead of a sudden error in ci building or pr checking.

Resolves https://github.com/nuxt/create-nuxt-app/issues/301