### PR TITLE
fix: turn off typescript 'no-undef' rule per docs

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -11,7 +11,7 @@ module.exports = {
     // Per the docs, the root no-unused-vars should be disabled:
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
     'no-unused-vars': 'off',
-    
+
     // https://github.com/typescript-eslint/typescript-eslint/blob/1cf9243/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
     'no-undef': 'off'
   }

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -10,6 +10,9 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { args: 'all', argsIgnorePattern: '^_' }],
     // Per the docs, the root no-unused-vars should be disabled:
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
-    'no-unused-vars': 'off'
+    'no-unused-vars': 'off',
+    
+    // https://github.com/typescript-eslint/typescript-eslint/blob/1cf9243/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+    'no-undef': 'off'
   }
 }


### PR DESCRIPTION
Docs say:
>We strongly recommend that you do not use the no-undef lint rule on TypeScript projects. The checks it provides are already provided by TypeScript without the need for configuration - TypeScript just does this significantly better.

Closes #140