### PR TITLE
docs: replace babel-eslint with @babel/eslint-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ $ yarn add -D eslint
 ## Full example
 
 A full example `.eslintrc` for a project with babel support:
-> Dont forget to `npm i -D babel-eslint` or `yarn add -D babel-eslint`
+> Dont forget to `npm i -D @babel/eslint-parser` or `yarn add -D @babel/eslint-parser`
 
 ```json
 {
   "root": true,
   "parserOptions": {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "sourceType": "module"
   },
   "extends": [


### PR DESCRIPTION
See https://github.com/babel/babel-eslint#note-babel-eslint-is-now-babeleslint-parser-and-has-moved-into-the-babel-monorepo