### PR TITLE
fix: update `jest/globals` env to `jest`

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -2,7 +2,7 @@ module.exports = {
   env: {
     browser: true,
     node: true,
-    'jest/globals': true
+    jest: true
   },
   extends: [
     'standard',


### PR DESCRIPTION
replace `{ 'jest/globals': true }` to `{ jest: true }`

https://github.com/nuxt/eslint-config/issues/171

https://github.com/jest-community/eslint-plugin-jest/issues/44#issue-286150080