### PR TITLE
fix: remove dependency on `eslint-plugin-standard`

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,7 +17,6 @@
     "eslint-plugin-jest": "^25.2.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.1",
-    "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-unicorn": "^37.0.1",
     "eslint-plugin-vue": "^7.20.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,11 +2797,6 @@ eslint-plugin-promise@^5.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.1.1.tgz#9674d11c056d1bafac38e4a3a9060be740988d90"
   integrity sha512-XgdcdyNzHfmlQyweOPTxmc7pIsS6dE4MvwhXWMQ2Dxs1XAL2GJDilUsjWen6TWik0aSI+zD/PqocZBblcm9rdA==
 
-eslint-plugin-standard@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz#c43f6925d669f177db46f095ea30be95476b1ee4"
-  integrity sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==
-
 eslint-plugin-unicorn@^37.0.1:
   version "37.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz#a2292dc302ffc0be1791e6ebbb4ae93242833f11"


### PR DESCRIPTION
`eslint-plugin-standard` was deprecated with v16 of `eslint-config-standard` as it is no longer necessary.

More info:
- https://www.npmjs.com/package/eslint-plugin-standard
- https://github.com/standard/standard/issues/1316

Feel free to request any changes you need me to do to get this merged 👍 