### PR TITLE
disable vue/multi-word-component-names rule for pages and layouts folder

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -128,5 +128,13 @@ module.exports = {
     'vue/max-attributes-per-line': ['error', {
       singleline: 5
     }]
-  }
+  },
+  overrides: [
+    {
+      files: ['pages/**/*.vue', 'layouts/**/*.vue'],
+      rules: {
+        'vue/multi-word-component-names': 'off',
+      },
+    },
+  ],
 }


### PR DESCRIPTION
vue/multi-word-component-names us a cool new rule, but I believe it does not make sense inside of nuxt's pages and layouts folder