### PR TITLE
chore: disable multiword-rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -128,7 +128,7 @@ module.exports = {
     'vue/max-attributes-per-line': ['error', {
       singleline: 5
     }],
-    
+
     // Disable necessity to have multi-word components.
     // Not ideal for pages
     'vue/multi-word-component-names': 'off'

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -128,9 +128,13 @@ module.exports = {
     'vue/max-attributes-per-line': ['error', {
       singleline: 5
     }],
-
-    // Disable necessity to have multi-word components.
-    // Not ideal for pages
-    'vue/multi-word-component-names': 'off'
-  }
+  },
+  overrides: [
+    {
+      files: ['pages/**/*.{js,ts,vue}', 'layouts/**/*.{js,ts,vue}'],
+      rules: {
+        'vue/multi-word-component-names': 'off',
+      }
+    }
+  ]
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -127,6 +127,10 @@ module.exports = {
     // Maximum 5 attributes per line instead of one
     'vue/max-attributes-per-line': ['error', {
       singleline: 5
-    }]
+    }],
+    
+    // Disable necessity to have multi-word components.
+    // Not ideal for pages
+    'vue/multi-word-component-names': 'off'
   }
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -127,7 +127,7 @@ module.exports = {
     // Maximum 5 attributes per line instead of one
     'vue/max-attributes-per-line': ['error', {
       singleline: 5
-    }],
+    }]
   },
   overrides: [
     {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -133,7 +133,7 @@ module.exports = {
     {
       files: ['pages/**/*.{js,ts,vue}', 'layouts/**/*.{js,ts,vue}'],
       rules: {
-        'vue/multi-word-component-names': 'off',
+        'vue/multi-word-component-names': 'off'
       }
     }
   ]


### PR DESCRIPTION
Not ideal for page components :( 

Resolves #192 
Better would be disabling it for the pages folder only I'd say 😋 