### PR TITLE
fix: disable vue/multi-word-component-names for files in subdirectories

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -130,10 +130,10 @@ module.exports = {
   overrides: [
     {
       files: [
-        'pages/**/*.{js,ts,vue}',
-        'layouts/**/*.{js,ts,vue}',
-        'app.{js,ts,vue}',
-        'error.{js,ts,vue}'
+        '**/pages/**/*.{js,ts,vue}',
+        '**/layouts/**/*.{js,ts,vue}',
+        '**/app.{js,ts,vue}',
+        '**/error.{js,ts,vue}'
       ],
       rules: {
         'vue/multi-word-component-names': 'off'


### PR DESCRIPTION
Closes #208