### PR TITLE
fix(eslint-config): disable multi-word component names for component dir

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -62,12 +62,14 @@ module.exports = {
       },
     },
     {
-      // These pages are not used directly by users so they can have one-word names.
       files: [
-        '**/pages/**/*.{js,ts,vue}',
-        '**/layouts/**/*.{js,ts,vue}',
-        '**/app.{js,ts,vue}',
-        '**/error.{js,ts,vue}'
+        // These pages are not used directly by users so they can have one-word names.
+        '**/pages/**/*.{js,ts,jsx,tsx,vue}',
+        '**/layouts/**/*.{js,ts,jsx,tsx,vue}',
+        '**/app.{js,ts,jsx,tsx,vue}',
+        '**/error.{js,ts,jsx,tsx,vue}',
+        // And these components are automatically prefixed to form multiple-word names.
+        '**/components/**/*.{js,ts,jsx,tsx,vue}',
       ],
       rules: { 'vue/multi-word-component-names': 'off' }
     },


### PR DESCRIPTION
resolves #261