### PR TITLE
docs(readme): update extends examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ yarn add -D eslint
 
 ```json
 {
-  "extends": ["@nuxtjs"]
+  "extends": ["@nuxt/eslint-config"]
 }
 ```
 
@@ -97,7 +97,7 @@ A full example `.eslintrc` for a project with babel support:
   "parserOptions": {
     "sourceType": "module"
   },
-  "extends": ["@nuxtjs"]
+  "extends": ["@nuxt/eslint-config"],
 }
 ```
 


### PR DESCRIPTION
```
> eslint .


Oops! Something went wrong! :(

ESLint: 8.33.0

ESLint couldn't find the config "@nuxtjs" to extend from. Please check that the name of the config is correct.

The config "@nuxtjs" was referenced from the config file in "/Users/iam/projects/demo-nuxt/.eslintrc".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```