### PR TITLE
fix: exclude subfolders of components folder from name rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -62,12 +62,13 @@ module.exports = {
       },
     },
     {
-      // These pages are not used directly by users so they can have one-word names.
       files: [
+        // These pages are not used directly by users so they can have one-word names.
         '**/pages/**/*.{js,ts,vue}',
         '**/layouts/**/*.{js,ts,vue}',
         '**/app.{js,ts,vue}',
         '**/error.{js,ts,vue}',
+        // These files should have multiple words in their names as they are within subdirectories.
         '**/components/*/**/*.{js,ts,vue}'
       ],
       rules: { 'vue/multi-word-component-names': 'off' }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -73,7 +73,7 @@ module.exports = {
     },
     {
       // Pages and layouts are required to have a single root element if transitions are enabled.
-      files: ['**/pages/**/*.{js,ts,vue}', '**/layouts/**/*.{js,ts,vue}'],
+      files: ['**/pages/**/*.{js,ts,vue}', '**/layouts/**/*.{js,ts,vue}', '**/components/*/**/*.{js,ts,vue}'],
       rules: { 'vue/no-multiple-template-root': 'error' }
     }
   ]

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -67,13 +67,14 @@ module.exports = {
         '**/pages/**/*.{js,ts,vue}',
         '**/layouts/**/*.{js,ts,vue}',
         '**/app.{js,ts,vue}',
-        '**/error.{js,ts,vue}'
+        '**/error.{js,ts,vue}',
+        '**/components/*/**/*.{js,ts,vue}'
       ],
       rules: { 'vue/multi-word-component-names': 'off' }
     },
     {
       // Pages and layouts are required to have a single root element if transitions are enabled.
-      files: ['**/pages/**/*.{js,ts,vue}', '**/layouts/**/*.{js,ts,vue}', '**/components/*/**/*.{js,ts,vue}'],
+      files: ['**/pages/**/*.{js,ts,vue}', '**/layouts/**/*.{js,ts,vue}'],
       rules: { 'vue/no-multiple-template-root': 'error' }
     }
   ]


### PR DESCRIPTION
Hi
I thought since the components in subfolders of components folder are automatically loaded with prefixed name of the folders out of the box, it should also ignore the naming rules in the subfolders

I thought it would be nice, so I made a PR