### PR TITLE
docs: fix typo in package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ yarn add -D eslint
 
 ```json
 {
-  "extends": ["@nuxt/eslint-config"]
+  "extends": ["@nuxtjs/eslint-config"]
 }
 ```
 


### PR DESCRIPTION
The section describing the @nuxtjs/eslint-config package use has a typo in it's code snippet. This PR corrects the typo in code snippet to extend ESlint config correctly