### PR TITLE
fix: prevent race condition running checker before eslint config is written

### DIFF
--- a/packages/module/src/modules/config/index.ts
+++ b/packages/module/src/modules/config/index.ts
@@ -40,8 +40,8 @@ export async function setupConfigGen(options: ModuleOptions, nuxt: Nuxt) {
   setupDevToolsIntegration(options, nuxt)
 
   await writeConfigFile()
-  nuxt.hook('builder:generateApp', () => {
-    writeConfigFile()
+  nuxt.hook('builder:generateApp', async () => {
+    await writeConfigFile()
   })
 
   if (autoInit) {


### PR DESCRIPTION
This PR prevents a race condition on the first run of `yarn dev` when this module has the `checker` option enabled.

### 🔗 Linked issue

resolves #652 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
