### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Sets `permissions: contents: read` at the workflow level on `.github/workflows/ci.yml`. The matrix job checks out the repo, sets up Node across the version matrix, installs dependencies and runs tests; nothing in the chain calls a GitHub API requiring more than read.

The reason this matters in practice is the supply-chain risk demonstrated by CVE-2025-30066 (the `tj-actions/changed-files` compromise in March 2025): a tampered third-party action exfiltrated `GITHUB_TOKEN` via the workflow logs, and the leaked token retained whatever scope was issued to it. Pinning each workflow to the minimum it actually uses bounds the runtime authority of every action that runs inside it, irrespective of what the repo or org default happens to be set to today. The in-file declaration also gives drift protection against a future default-widening change and registers with OpenSSF Scorecard's Token-Permissions check.

Validated locally with `yaml.safe_load`.
