### PR TITLE
docs: normalize module terminology in quick setup

### DIFF
--- a/docs/content/1.packages/0.module.md
+++ b/docs/content/1.packages/0.module.md
@@ -39,7 +39,7 @@ Once you start your Nuxt app, a `eslint.config.mjs` file will be generated under
 
 :::callout{icon="i-catppuccin-typescript"}
 
-If you are using TypeScript, you need to install the `typescript` in your project:
+If you are using TypeScript, you need to install the `typescript` module in your project:
 
 ::code-group
 ```bash [yarn]


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

i am walking through the [Nuxt Crash Course from Syntax](https://youtu.be/RhZZ0whiuT8?si=n8ZkiJVgSSWN0vUw) and noticed the phrasing of:

> install the `typescript` in your project

located near the top of the [Quick Setup](https://eslint.nuxt.com/packages/module#quick-setup) section of the `@nuxt/eslint` module docs.

whereas a more seamless, and potentially grammatical, way to state this might be:

> install the `typescript` module in your project

hopefully this is the beginning of a long and healthy relationship between myself and nuxt :) thanks for being a part of my journey ✌🏻 

(no ai/llm was used in the discovery, nor execution - of this patch)
