### PR TITLE
chore: add eslint plugin package metadata

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/nuxt/eslint.git",
     "directory": "packages/eslint-plugin"
   },
+  "bugs": {
+    "url": "https://github.com/nuxt/eslint/issues"
+  },
+  "homepage": "https://github.com/nuxt/eslint#readme",
   "exports": {
     ".": "./dist/index.mjs"
   },


### PR DESCRIPTION
### 🔗 Linked issue

Metadata-only package manifest cleanup.

### ❓ Type of change

- [x] 📖 Documentation / package metadata

### 📚 Description

Adds standard npm support metadata to `@nuxt/eslint-plugin`:

- `bugs.url` points to the Nuxt ESLint issue tracker
- `homepage` points to the repository README

This makes the package metadata easier for npm users and registry tooling to discover without changing runtime code, dependencies, exports, or build output.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
