### PR TITLE
chore: add eslint config package metadata

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,6 +7,10 @@
     "url": "git+https://github.com/nuxt/eslint.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/nuxt/eslint/issues"
+  },
+  "homepage": "https://github.com/nuxt/eslint#readme",
   "license": "MIT",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
### 🔗 Linked issue

Metadata-only package manifest cleanup.

### ❓ Type of change

- [x] 📖 Documentation / package metadata

### 📚 Description

Adds standard npm support metadata to `@nuxt/eslint-config`:

- `bugs.url` points to the Nuxt ESLint issue tracker
- `homepage` points to the repository README

This makes the package metadata easier for npm users and registry tooling to discover without changing runtime code, dependencies, exports, or build output.

### ✅ Verification

- Parsed `packages/eslint-config/package.json` and confirmed `name`, `license`, `homepage`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` from `packages/eslint-config`
- `git diff --check`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.