### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@nuxt/eslint-config",
   "version": "1.16.0",
+  "homepage": "https://github.com/nuxt/eslint",
+  "bugs": {
+    "url": "https://github.com/nuxt/eslint/issues"
+  },
   "description": "ESLint config for Nuxt projects",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds missing `bugs, homepage` metadata to `packages/eslint-config/package.json`.

Fixes npm tooling unable to resolve package metadata.