### PR TITLE
fix: add eslint config package metadata

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,6 +7,10 @@
     "url": "git+https://github.com/nuxt/eslint.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/nuxt/eslint/issues"
+  },
+  "homepage": "https://github.com/nuxt/eslint#readme",
   "license": "MIT",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- add missing `bugs` metadata for `@nuxt/eslint-config`
- add package `homepage` metadata matching the existing package convention

## Verification
- `node` script loaded `packages/eslint-config/package.json` and confirmed `bugs.url` and `homepage` are present
- `git diff --check`

Bounty: charles-openclaw/charles-microbounties#1206