### PR TITLE
chore: add package support metadata

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,6 +7,10 @@
     "url": "git+https://github.com/nuxt/eslint.git",
     "directory": "packages/eslint-config"
   },
+  "bugs": {
+    "url": "https://github.com/nuxt/eslint/issues"
+  },
+  "homepage": "https://github.com/nuxt/eslint#readme",
   "license": "MIT",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",

--- a/packages/module/package.json
+++ b/packages/module/package.json
@@ -9,6 +9,10 @@
     "url": "git+https://github.com/nuxt/eslint.git",
     "directory": "packages/module"
   },
+  "bugs": {
+    "url": "https://github.com/nuxt/eslint/issues"
+  },
+  "homepage": "https://github.com/nuxt/eslint#readme",
   "exports": {
     ".": "./dist/module.mjs"
   },


### PR DESCRIPTION
## Summary
- add `bugs.url` and `homepage` metadata to `@nuxt/eslint-config`
- add the same support metadata to `@nuxt/eslint`
- match the metadata shape already present in `@nuxt/eslint-plugin`

## Notes
This only updates package metadata in the two package manifests. Runtime code, dependencies, exports, versions, and package contents are unchanged.

## Validation
- `node` metadata assertion for `packages/eslint-config/package.json` and `packages/module/package.json`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm run build`
- `corepack pnpm -C playground exec nuxi prepare`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `npm pack --dry-run --json ./packages/eslint-config`
- `npm pack --dry-run --json ./packages/module`
- `git diff --check`
