### PR TITLE
 fix(eslint-config): disallow comments as extra template root 

### DIFF
--- a/packages/eslint-config/src/configs/nuxt.ts
+++ b/packages/eslint-config/src/configs/nuxt.ts
@@ -34,6 +34,13 @@ export default function nuxt(options: NuxtESLintConfigOptions): Linter.Config[] 
     },
   })
 
+  // Pages, layouts and server components must have a single root element
+  // (comments count as one) so Nuxt can wrap them in `<Transition>`/`<KeepAlive>`.
+  //
+  // See documentation:
+  // - https://nuxt.com/docs/4.x/directory-structure/app/pages
+  // - https://nuxt.com/docs/4.x/directory-structure/app/layouts#enable-layouts
+  // - https://nuxt.com/docs/4.x/directory-structure/app/components#standalone-server-components
   if (fileSingleRoot.length)
     configs.push({
       name: 'nuxt/vue/single-root',

--- a/packages/eslint-config/src/configs/nuxt.ts
+++ b/packages/eslint-config/src/configs/nuxt.ts
@@ -46,7 +46,7 @@ export default function nuxt(options: NuxtESLintConfigOptions): Linter.Config[] 
       name: 'nuxt/vue/single-root',
       files: fileSingleRoot,
       rules: {
-        'vue/no-multiple-template-root': 'error',
+        'vue/no-multiple-template-root': ['error', { disallowComments: true }],
       },
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

While working on [Nutsack Lint](https://github.com/Zerya-Dev/nustack/tree/master/modules/lint) I decided to clean up
some old rules in my configuration overrides. I found out that `nuxt/vue/single-root` rule allows for comments, which is
explicitly disallowed in the documentation:

> Pages must have a single root element to allow [route transitions](https://nuxt.com/docs/4.x/getting-started/transitions) between pages. HTML comments are considered elements as well.

I also decided to add a bit more documentation about this rule, so next developers can easier find the reasoning behind this rule