### PR TITLE
fix(eslint-plugin): handle some bugs with spread operators

### DIFF
--- a/packages/eslint-plugin/src/rules/nuxt-config-keys-order/nuxt-config-keys-order.test.ts
+++ b/packages/eslint-plugin/src/rules/nuxt-config-keys-order/nuxt-config-keys-order.test.ts
@@ -27,6 +27,7 @@ run({
     ssr: true
   }
 }`,
+    'export default defineNuxtConfig()',
     // Unknown keys come after known keys (sorted alphabetically among themselves)
     `export default {
   modules: [],
@@ -103,6 +104,23 @@ run({
       output: 'export default { modules: [], build: {}, nitro: {}, }',
       errors: [{
         messageId: 'default',
+      }],
+    },
+    // Spread element as the first property
+    {
+      code: `export default defineNuxtConfig({
+  ...(condition ? {} : { buildDir: '.nuxt' }),
+  experimental: {},
+  routeRules: {},
+})`,
+      output: `export default defineNuxtConfig({
+  ...(condition ? {} : { buildDir: '.nuxt' }),
+  routeRules: {},
+  experimental: {},
+})`,
+      errors: [{
+        messageId: 'default',
+        data: { a: 'routeRules', b: 'experimental' },
       }],
     },
     // Dirs and runtime configs

--- a/packages/eslint-plugin/src/rules/nuxt-config-keys-order/nuxt-config-keys-order.ts
+++ b/packages/eslint-plugin/src/rules/nuxt-config-keys-order/nuxt-config-keys-order.ts
@@ -27,7 +27,7 @@ export const rule = createRule<MessageIds, Options>({
         if (node.declaration.type === 'ObjectExpression') {
           object = node.declaration
         }
-        else if (node.declaration.type === 'CallExpression' && node.declaration.arguments[0].type === 'ObjectExpression') {
+        else if (node.declaration.type === 'CallExpression' && node.declaration.arguments[0]?.type === 'ObjectExpression') {
           object = node.declaration.arguments[0]
         }
         if (!object) {
@@ -186,12 +186,28 @@ function sortAst<T extends Tree.Node>(
   //   oldContent: ctx.context.sourceCode.text.slice(rangeStart, rangeEnd),
   // })
 
+  // Name the first pair that actually moved, skipping entries without a name
+  // (e.g. spread elements), so the message always references real config keys.
+  let a: string | undefined
+  let b: string | undefined
+  for (let i = 0; i < reordered.length; i++) {
+    if (reordered[i] === list[i])
+      continue
+    const nameA = names.get(reordered[i])?.[0]
+    const nameB = names.get(list[i])?.[0]
+    if (nameA && nameB) {
+      a = nameA
+      b = nameB
+      break
+    }
+  }
+
   context.report({
     node,
     messageId: 'default',
     data: {
-      a: names.get(reordered[0])![0]!,
-      b: names.get(reordered[1])![0]!,
+      a: a ?? '',
+      b: b ?? '',
     },
     fix(fixer) {
       return fixer.replaceTextRange([rangeStart, rangeEnd], newContent)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted [here](https://github.com/nuxt/nuxt/actions/runs/30265444656/job/89974900129?pr=35853#step:8:11)

```
Oops! Something went wrong! :(

ESLint: 10.7.0

TypeError: Cannot read properties of null (reading '0')
Occurred while linting /home/runner/work/nuxt/nuxt/test/fixtures/payload-cache-leak/nuxt.config.ts:3
Rule: "nuxt/nuxt-config-keys-order"
    at sortAst (file:///home/runner/work/nuxt/nuxt/node_modules/.pnpm/@nuxt+eslint-plugin@1.16.0_eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2__supports-color@10.2.2_typescript@6.0.3/node_modules/@nuxt/eslint-plugin/dist/index.mjs:402:33)
    at sort (file:///home/runner/work/nuxt/nuxt/node_modules/.pnpm/@nuxt+eslint-plugin@1.16.0_eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2__supports-color@10.2.2_typescript@6.0.3/node_modules/@nuxt/eslint-plugin/dist/index.mjs:297:10)
    at ExportDefaultDeclaration (file:///home/runner/work/nuxt/nuxt/node_modules/.pnpm/@nuxt+eslint-plugin@1.16.0_eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2__supports-color@10.2.2_typescript@6.0.3/node_modules/@nuxt/eslint-plugin/dist/index.mjs:284:26)
    at ruleErrorHandler (/home/runner/work/nuxt/nuxt/node_modules/.pnpm/eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2/node_modules/eslint/lib/linter/linter.js:645:33)
    at /home/runner/work/nuxt/nuxt/node_modules/.pnpm/eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2/node_modules/eslint/lib/linter/source-code-visitor.js:76:46
    at Array.forEach (<anonymous>)
    at SourceCodeVisitor.callSync (/home/runner/work/nuxt/nuxt/node_modules/.pnpm/eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2/node_modules/eslint/lib/linter/source-code-visitor.js:76:30)
    at /home/runner/work/nuxt/nuxt/node_modules/.pnpm/eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2/node_modules/eslint/lib/linter/source-code-traverser.js:291:18
    at Array.forEach (<anonymous>)
    at SourceCodeTraverser.traverseSync (/home/runner/work/nuxt/nuxt/node_modules/.pnpm/eslint@10.7.0_jiti@2.7.0_supports-color@10.2.2/node_modules/eslint/lib/linter/source-code-traverser.js:290:10)
```