### PR TITLE
fix(module): resolve ESLint class from the main entry in checker

### DIFF
--- a/packages/module/src/modules/checker.ts
+++ b/packages/module/src/modules/checker.ts
@@ -33,9 +33,9 @@ export async function setupESLintChecker(moduleOptions: ModuleOptions, nuxt: Nux
 
   // Vite: https://github.com/ModyQyW/vite-plugin-eslint2#eslintpath
   // Webpack: https://github.com/webpack-contrib/eslint-webpack-plugin#configtype
-  options.eslintPath ||= options.configType === 'flat'
-    ? 'eslint/use-at-your-own-risk'
-    : 'eslint'
+  // `eslint/use-at-your-own-risk` no longer exposes a class in ESLint 10, and the
+  // main entry has been flat-config aware since ESLint 9, which is our lowest peer.
+  options.eslintPath ||= 'eslint'
 
   const configPaths = [
     '.eslintignore',


### PR DESCRIPTION
`checker: true` fails to start on ESLint 10 with `TypeError: ESLintClass is not a constructor`.

For flat config the checker points `eslintPath` at `eslint/use-at-your-own-risk`, but ESLint 10 dropped the class exports from that entry. It now resolves to `{ builtinRules, shouldUseFlatConfig }` only, so `vite-plugin-eslint2` gets `undefined` where it expects `loadESLint` / `ESLint` / `FlatESLint` / `LegacyESLint`, and calls `new undefined()`.

The main `eslint` entry exports both `ESLint` and `loadESLint()`, and has been flat-config aware since v9 — the lowest version in the peer range (`^9.0.0 || ^10.0.0`). The separate entry isn't needed anymore for either config type.

Verified on eslint 10.8.1, nuxt 4.5.2, vite 8.2.1, vite-plugin-eslint2 5.3.0: with `eslintPath: 'eslint'` the checker lints on start and on save as expected, while the default currently throws.

Closes #657
