### PR TITLE
fix(module): resolve the ESLint class from the main entry in checker

### DIFF
--- a/packages/module/src/modules/checker.ts
+++ b/packages/module/src/modules/checker.ts
@@ -33,9 +33,9 @@ export async function setupESLintChecker(moduleOptions: ModuleOptions, nuxt: Nux
 
   // Vite: https://github.com/ModyQyW/vite-plugin-eslint2#eslintpath
   // Webpack: https://github.com/webpack-contrib/eslint-webpack-plugin#configtype
-  options.eslintPath ||= options.configType === 'flat'
-    ? 'eslint/use-at-your-own-risk'
-    : 'eslint'
+  // `eslint/use-at-your-own-risk` no longer exposes a class in ESLint 10, and the
+  // main entry has been flat-config aware since ESLint 9, which is our lowest peer.
+  options.eslintPath ||= 'eslint'
 
   const configPaths = [
     '.eslintignore',


### PR DESCRIPTION
`checker: true` throws on ESLint 10 and the dev server never starts linting:

```
Failed to initialize ESLint. Have you installed and configured correctly? TypeError: ESLintClass is not a constructor
```

For flat config the checker defaults `eslintPath` to `eslint/use-at-your-own-risk`, but ESLint 10 removed the class exports from that entry:

```js
await import('eslint/use-at-your-own-risk')
// ESLint 9.39.5:  { builtinRules, FlatESLint, LegacyESLint, shouldUseFlatConfig, FileEnumerator }
// ESLint 10.8.1: { builtinRules, shouldUseFlatConfig }
```

`vite-plugin-eslint2` looks for `loadESLint` / `ESLint` / `FlatESLint` / `LegacyESLint` on that module, finds none of them and ends up calling `new undefined()`.

The main `eslint` entry exports `ESLint` and `loadESLint()`, and has been flat-config aware since v9 — the lowest version in the peer range (`^9.0.0 || ^10.0.0`). So the dedicated entry is no longer needed for either config type, and the branch can go away entirely.

Checked with eslint 10.8.1, nuxt 4.5.2, vite 8.2.1, vite-plugin-eslint2 5.3.0: the checker lints on start and on save again. Same result as the `eslintPath: 'eslint'` workaround @sebbayer found in #657.

Closes #657
